### PR TITLE
Patches from NiceDay Mobile App

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -8,7 +8,7 @@
  */
 package com.twiliorn.library;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;

--- a/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
+++ b/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
@@ -21,8 +21,8 @@ public class RNVideoViewGroup extends ViewGroup {
     private int videoWidth = 0;
     private int videoHeight = 0;
     private final Object layoutSync = new Object();
+    private int scalesType = 0;
     private RendererCommon.ScalingType scalingType = RendererCommon.ScalingType.SCALE_ASPECT_FILL;
-
 
     public RNVideoViewGroup(Context context) {
         super(context);
@@ -57,6 +57,10 @@ public class RNVideoViewGroup extends ViewGroup {
         this.scalingType = scalingType;
     }
 
+    public void setScalesType(int scalesType) {
+        this.scalesType = scalesType;
+    }
+
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
         int height = b - t;
@@ -64,8 +68,10 @@ public class RNVideoViewGroup extends ViewGroup {
         if (height == 0 || width == 0) {
             l = t = r = b = 0;
         } else {
+            RendererCommon.ScalingType overriddenScaleType;
             int videoHeight;
             int videoWidth;
+
             synchronized (layoutSync) {
                 videoHeight = this.videoHeight;
                 videoWidth = this.videoWidth;
@@ -77,8 +83,11 @@ public class RNVideoViewGroup extends ViewGroup {
                 videoWidth = 640;
             }
 
+            if (this.scalesType == 1) overriddenScaleType = RendererCommon.ScalingType.SCALE_ASPECT_FIT;
+            else overriddenScaleType = RendererCommon.ScalingType.SCALE_ASPECT_FILL;
+
             Point displaySize = RendererCommon.getDisplaySize(
-                    this.scalingType,
+                    overriddenScaleType,
                     videoWidth / (float) videoHeight,
                     width,
                     height
@@ -91,4 +100,22 @@ public class RNVideoViewGroup extends ViewGroup {
         }
         surfaceViewRenderer.layout(l, t, r, b);
     }
+
+    // requestLayout and measureAndLayout is a hack to make sure that
+    // layout is always triggered whenever one of the props is changing
+    @Override
+    public void requestLayout() {
+        super.requestLayout();
+        post(measureAndLayout);
+    }
+
+    private final Runnable measureAndLayout = new Runnable() {
+        @Override
+        public void run() {
+            measure(
+                MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+            layout(getLeft(), getTop(), getRight(), getBottom());
+        }
+    };
 }

--- a/android/src/main/java/com/twiliorn/library/TwilioRemotePreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioRemotePreviewManager.java
@@ -7,7 +7,7 @@
 
 package com.twiliorn.library;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -29,7 +29,6 @@ public class TwilioRemotePreviewManager extends SimpleViewManager<TwilioRemotePr
 
     @ReactProp(name = "scaleType")
     public void setScaleType(TwilioRemotePreview view, @Nullable String scaleType) {
-
       if (scaleType.equals("fit")) {
         view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FIT);
       } else {
@@ -37,15 +36,23 @@ public class TwilioRemotePreviewManager extends SimpleViewManager<TwilioRemotePr
       }
     }
 
+    @ReactProp(name = "scalesType")
+    public void setScalesType(TwilioRemotePreview view, @Nullable int scalesType) {
+        // This props is made specially for nice day to allow double tapping to change the video size.
+        // Details: https://github.com/senseobservationsystems/goalie-2-mobile-app/pull/2941
+        // We add request layout at the end of the function to always trigger layouting whenever
+        // value of this props changes.
+        view.setScalesType(scalesType);
+        view.requestLayout();
+    }
+
     @ReactProp(name = "trackSid")
     public void setTrackId(TwilioRemotePreview view, @Nullable String trackSid) {
-
         Log.i("CustomTwilioVideoView", "Initialize Twilio REMOTE");
         Log.i("CustomTwilioVideoView", trackSid);
         myTrackSid = trackSid;
         CustomTwilioVideoView.registerPrimaryVideoView(view.getSurfaceViewRenderer(), trackSid);
     }
-
 
     @Override
     protected TwilioRemotePreview createViewInstance(ThemedReactContext reactContext) {

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
@@ -7,7 +7,7 @@
 
 package com.twiliorn.library;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -116,7 +116,11 @@ RCT_EXPORT_METHOD(setRemoteAudioPlayback:(NSString *)participantSid enabled:(BOO
     }
 }
 
-RCT_EXPORT_METHOD(startLocalVideo:(BOOL)screenShare) {
+RCT_EXPORT_METHOD(startLocalVideo:(BOOL)screenShare enabled:(BOOL) enabled) {
+    if (!enabled || self.localVideoTrack != nil) {
+        return;
+    }
+
   if (screenShare) {
     UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
     self.screen = [[TVIScreenCapturer alloc] initWithView:rootViewController.view];
@@ -127,6 +131,11 @@ RCT_EXPORT_METHOD(startLocalVideo:(BOOL)screenShare) {
     self.camera.delegate = self;
 
     self.localVideoTrack = [TVILocalVideoTrack trackWithCapturer:self.camera enabled:YES constraints:[self videoConstraints] name:@"camera"];
+  }
+
+  TVILocalParticipant *localParticipant = self.room.localParticipant;
+  if (localParticipant != nil && self.localVideoTrack != nil) {
+      [localParticipant publishVideoTrack:self.localVideoTrack];
   }
 }
 

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -136,7 +136,6 @@ export default class extends Component {
 
   componentWillMount () {
     this._registerEvents()
-    this._startLocalVideo()
     this._startLocalAudio()
   }
 
@@ -165,6 +164,7 @@ export default class extends Component {
    * Enable or disable local video
    */
   setLocalVideoEnabled (enabled) {
+    this._startLocalVideo(enabled)
     return TWVideoModule.setLocalVideoEnabled(enabled)
   }
 
@@ -201,7 +201,8 @@ export default class extends Component {
    * @param  {String} roomName    The connecting room name
    * @param  {String} accessToken The Twilio's JWT access token
    */
-  connect ({ roomName, accessToken }) {
+  connect ({ roomName, accessToken, enableVideo }) {
+    this._startLocalVideo(enableVideo)
     TWVideoModule.connect(accessToken, roomName)
   }
 
@@ -212,9 +213,9 @@ export default class extends Component {
     TWVideoModule.disconnect()
   }
 
-  _startLocalVideo () {
+  _startLocalVideo (enabled) {
     const screenShare = this.props.screenShare || false
-    TWVideoModule.startLocalVideo(screenShare)
+    TWVideoModule.startLocalVideo(screenShare, enabled)
   }
 
   _stopLocalVideo () {


### PR DESCRIPTION
This PR contain two changes:
- Previously, this lib will always create a video track, even if we set it to audio as we connect. This will in turn made app crash if user haven't give any permission to use camera. This PR changes so this lib will always respect its is-video-enabled setting.
- This PR add a prop that will determine the size of video. To support this feature in android, we add a hack called `measureAndLayout`, to make sure that this lib always rerender its layout whenever its props is changed.