### PR TITLE
Fix Audio Device Order On Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,6 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$androidSupportVersion"
     implementation "com.twilio:video-android:5.5.0"
     implementation 'org.webrtc:google-webrtc:1.0.+'
-    implementation "com.twilio:audioswitch:0.1.5"
+    implementation "com.twilio:audioswitch:1.0.1"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }


### PR DESCRIPTION
This PR upgrades the AudioSwitch library to the latest version and fixes the audio device order for connected devices in android.

By default the AudioSwitch Library uses this order:
1) Bluetooth
2) Wired
3) Earpiece
4) Speakerphone

This makes sense for a normal VOIP call but doesn't make sense for a video call.

This PR changes the audio device order to be:

1) Bluetooth
2) Wired
3) Speakerphone

Removing the possibility of the Earpiece device being used.