### PR TITLE
Set default audio session mode in stereo mode to fix a bug in iOS 14

### DIFF
--- a/ios/RCTTWCustomAudioDevice.m
+++ b/ios/RCTTWCustomAudioDevice.m
@@ -806,8 +806,16 @@ static OSStatus CustomAudioDeviceRecordCallback(void *refCon,
             NSLog(@"CustomAudioDevice [ERROR] setting session category: %@", error);
         }
         
-        if (![session setMode:AVAudioSessionModeDefault error:&error]) {
-            NSLog(@"CustomAudioDevice [ERROR] setting session category: %@", error);
+        if (@available(iOS 14, *)) {
+            // We have to explcitiy do this for iOS 14,AVAudioSessionModeVideoChat is completely mono in iOS 14+
+            if (![session setMode:AVAudioSessionModeDefault error:&error]) {
+                NSLog(@"CustomAudioDevice [ERROR] setting session mode: %@", error);
+            }
+        } else {
+            // We have to explicitly do this for iOS < 14,AVAudioSessionModeDefault stays mono in iOS < 14
+            if (![session setMode:AVAudioSessionModeVideoChat error:&error]) {
+                NSLog(@"CustomAudioDevice [ERROR] setting session mode: %@", error);
+            }
         }
     } else {
         if (![session setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetoothA2DP|AVAudioSessionCategoryOptionAllowBluetooth error:&error]) {
@@ -815,7 +823,7 @@ static OSStatus CustomAudioDeviceRecordCallback(void *refCon,
         }
         
         if (![session setMode:AVAudioSessionModeVideoChat error:&error]) {
-            NSLog(@"CustomAudioDevice [ERROR] setting session category: %@", error);
+            NSLog(@"CustomAudioDevice [ERROR] setting session mode: %@", error);
         }
     }
     

--- a/ios/RCTTWCustomAudioDevice.m
+++ b/ios/RCTTWCustomAudioDevice.m
@@ -805,14 +805,18 @@ static OSStatus CustomAudioDeviceRecordCallback(void *refCon,
         if (![session setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetoothA2DP error:&error]) {
             NSLog(@"CustomAudioDevice [ERROR] setting session category: %@", error);
         }
+        
+        if (![session setMode:AVAudioSessionModeDefault error:&error]) {
+            NSLog(@"CustomAudioDevice [ERROR] setting session category: %@", error);
+        }
     } else {
         if (![session setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetoothA2DP|AVAudioSessionCategoryOptionAllowBluetooth error:&error]) {
             NSLog(@"CustomAudioDevice [ERROR] setting session category: %@", error);
         }
-    }
-//
-    if (![session setMode:AVAudioSessionModeVideoChat error:&error]) {
-        NSLog(@"CustomAudioDevice [ERROR] setting session category: %@", error);
+        
+        if (![session setMode:AVAudioSessionModeVideoChat error:&error]) {
+            NSLog(@"CustomAudioDevice [ERROR] setting session category: %@", error);
+        }
     }
     
     if (![session setPreferredSampleRate:kPreferredSampleRate error:&error]) {


### PR DESCRIPTION
With iOS 14 the `AVAudioSessionModeVideoChat` is completely mono so we have to make sure that we set the session mode to be `AVAudioSessionModeDefault` when we are in stereo mode.