### PR TITLE
Add Custom Event in CustomTwilioVideoView 

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -30,11 +30,14 @@ import android.util.Log;
 import android.view.View;
 
 import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.twilio.video.AudioTrackPublication;
 import com.twilio.video.BaseTrackStats;
@@ -1069,7 +1072,10 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     // ===== EVENTS TO RN ==========================================================================
 
     void pushEvent(View view, String name, WritableMap data) {
-        eventEmitter.receiveEvent(view.getId(), name, data);
+        ReactContext context= (ReactContext) view.getContext();
+        EventDispatcher eventDispatcher =
+                context.getNativeModule(UIManagerModule.class).getEventDispatcher();
+        eventDispatcher.dispatchEvent(new TwilioEvent(view.getId(),name,data));
     }
 
     public static void registerPrimaryVideoView(PatchedVideoView v, String trackSid) {

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -1070,7 +1070,11 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         pushEvent(CustomTwilioVideoView.this, ON_PARTICIPANT_REMOVED_VIDEO_TRACK, event);
     }
     // ===== EVENTS TO RN ==========================================================================
-
+    /**
+     * Dispatch custom event (`TwilioEvent`) to avoid error 
+     * `Caused by: java.lang.RuntimeException: Cannot convert argument of type class com.twiliorn.library.CustomTwilioVideoView`
+     * github.com/senseobservationsystems/goalie-2-mobile-app/issues/3416
+     */
     void pushEvent(View view, String name, WritableMap data) {
         ReactContext context= (ReactContext) view.getContext();
         EventDispatcher eventDispatcher =

--- a/android/src/main/java/com/twiliorn/library/TwilioEvent.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioEvent.java
@@ -6,6 +6,9 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
+/**
+ * Class to hold event data.
+ */
 public class TwilioEvent extends Event<TwilioEvent> {
     private  WritableMap event;
     private String eventName;

--- a/android/src/main/java/com/twiliorn/library/TwilioEvent.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioEvent.java
@@ -1,0 +1,26 @@
+package com.twiliorn.library;
+
+import android.util.Log;
+
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+public class TwilioEvent extends Event<TwilioEvent> {
+    private  WritableMap event;
+    private String eventName;
+    @Override
+    public String getEventName() {
+        return eventName;
+    }
+    public TwilioEvent(int viewId, String eventName, WritableMap event) {
+        super.init(viewId);
+        this.event=event;
+        this.eventName=eventName;
+    }
+
+    @Override
+    public void dispatch(RCTEventEmitter rctEventEmitter) {
+        rctEventEmitter.receiveEvent(getViewTag(), eventName, event);
+    }
+}


### PR DESCRIPTION
## Introduction

The type of this PR is: Enhancement (improve an implementation, refactor, chores)



- This PR is related to #[3524](https://github.com/senseobservationsystems/goalie-2-mobile-app/pull/3524) <!-- issue-nr(s) -->

## Description
This PR fix crash when doing video call by using custom event for CustomTwilioVideoView.

## Test Plan
- Build debug/production.
- Do a video call.
- App should not crashed when call connected.

## Checklist
<!--
Put an `x` in the boxes that apply.
Use `~~` around the checklist items that are not applicable to this PR.
Examples:
- [x] I've done this
- ~~[ ] I don't need this~~
-->
- [ ] Code quality is high (good comments, no unneeded changes, good names)
- [ ] Translation keys are used and added to the [spreadsheet](https://docs.google.com/spreadsheets/d/1-6DFzonKzuv_jHqRKGsjmj7dJynrUCZmwT5RBdGtavw/edit#gid=932531650) and Lisa is tagged to inform her of the changes
- [ ] Images are optimized using ImageOptim
- [ ] Unit tests are added to test behavior
<details><summary>Labels</summary>

- `T:` type of PR
Bug-fix, Chore, Enhancement
- `F:` feature, so that related PRs can easily be grouped
FeatureName
- `D:` relevant platform
Android, iOS
- `Native:` if this PR requires a native release
Android, iOS
- `S:` external deps
Waiting for backend, Waiting for translations
- Helpers
WIP, Direct PR
</details>

- [ ] Labels are added
- [ ] Assigned to a milestone (ask the App Lead if unsure)

## For the reviewers
Copy-paste this in a comment below, post it, and start checking things.

<details>
<summary>Reviewer Comment</summary>

```
### Security
- [ ] If the `eval` function is used, unvalidated user input is not passed to the function (Code Injection).
- [ ] I can verify the new dependency added in the `package.json` does not seem malicious.
### Review
- [ ] I understand the purpose of this PR
- [ ] I understand the code of this PR
- [ ] Target branch is correct(`develop`, `release/alpha`, `release/beta` or `release/prod`)
- [ ] Works correctly on Android 5 and higher
- [ ] Works correctly on iOS
- [ ] The code quality is high (proper location, proper structure, good names...)
- [ ] There's enough documentation to explain what is going on.
#### Just before merging
- [ ] All my requested changes have been resolved
```

</details>
