### PR TITLE
Fix Android z-index

### DIFF
--- a/android/src/main/java/com/twiliorn/library/TwilioRemotePreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioRemotePreview.java
@@ -22,7 +22,10 @@ public class TwilioRemotePreview extends RNVideoViewGroup {
         Log.i("CustomTwilioVideoView", "Remote Prview Construct");
         Log.i("CustomTwilioVideoView", trackSid);
 
-
         CustomTwilioVideoView.registerPrimaryVideoView(this.getSurfaceViewRenderer(), trackSid);
+    }
+
+    public void applyZOrder(boolean applyZOrder) {
+        this.getSurfaceViewRenderer().applyZOrder(applyZOrder);
     }
 }

--- a/android/src/main/java/com/twiliorn/library/TwilioRemotePreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioRemotePreviewManager.java
@@ -58,6 +58,11 @@ public class TwilioRemotePreviewManager extends SimpleViewManager<TwilioRemotePr
         CustomTwilioVideoView.registerPrimaryVideoView(view.getSurfaceViewRenderer(), trackSid);
     }
 
+    @ReactProp(name = "applyZOrder", defaultBoolean = false)
+    public void setApplyZOrder(TwilioRemotePreview view, boolean applyZOrder) {
+      view.applyZOrder(applyZOrder);
+    }
+
     @Override
     protected TwilioRemotePreview createViewInstance(ThemedReactContext reactContext) {
         return new TwilioRemotePreview(reactContext, myTrackSid);

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
@@ -18,10 +18,7 @@ public class TwilioVideoPreview extends RNVideoViewGroup {
         CustomTwilioVideoView.registerThumbnailVideoView(this.getSurfaceViewRenderer());
     }
 
-    // Previously, we always call this function for all Local Video.
-    // But, this results in a problem where camera view can be rendered below
-    // Local Video on the middle of Call Screen.
-    public void applyZOrder() {
-        this.getSurfaceViewRenderer().applyZOrder(true);
+    public void applyZOrder(boolean applyZOrder) {
+        this.getSurfaceViewRenderer().applyZOrder(applyZOrder);
     }
 }

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
@@ -52,8 +52,13 @@ public class TwilioVideoPreviewManager extends SimpleViewManager<TwilioVideoPrev
     @ReactProp(name = "onTop")
     public void setOnTop(TwilioVideoPreview view, @Nullable boolean onTop) {
         if (onTop) {
-            view.applyZOrder();
+            view.applyZOrder(true);
         }
+    }
+
+    @ReactProp(name = "applyZOrder", defaultBoolean = true)
+    public void setApplyZOrder(TwilioVideoPreview view, boolean applyZOrder) {
+      view.applyZOrder(applyZOrder);
     }
 
     @Override

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,9 @@ declare module "react-native-twilio-video-webrtc" {
     scalesType: number;
     onTop?: boolean;
     ref?: React.Ref<any>;
+    applyZOrder?: boolean;
   }
-  
+
   export interface TrackIdentifier {
     participantSid: string;
     videoTrackSid: string;
@@ -65,7 +66,7 @@ declare module "react-native-twilio-video-webrtc" {
   export type RoomErrorEventCb = (t: RoomErrorEventArgs) => void;
 
   export type ParticipantEventCb = (p: ParticipantEventArgs) => void;
-  
+
   export type NetworkLevelChangeEventCb = (p: NetworkLevelChangeEventArgs) => void;
 
   export type TwilioVideoProps = ViewProps & {

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ declare module "react-native-twilio-video-webrtc" {
     trackIdentifier: TrackIdentifier;
     ref?: React.Ref<any>;
     scalesType?: number;
+    applyZOrder?: boolean;
   }
 
   export interface Participant {

--- a/src/TwilioVideoLocalView.android.js
+++ b/src/TwilioVideoLocalView.android.js
@@ -6,10 +6,12 @@
  */
 
 import { requireNativeComponent, View } from 'react-native'
+import PropTypes from 'prop-types'
 import React from 'react'
 
 const propTypes = {
-  ...View.propTypes
+  ...View.propTypes,
+  applyZOrder: PropTypes.bool
 }
 
 class TwilioVideoPreview extends React.Component {

--- a/src/TwilioVideoParticipantView.android.js
+++ b/src/TwilioVideoParticipantView.android.js
@@ -26,7 +26,8 @@ class TwilioRemotePreview extends React.Component {
     importantForAccessibility: PropTypes.string,
     accessibilityLabel: PropTypes.string,
     nativeID: PropTypes.string,
-    testID: PropTypes.string
+    testID: PropTypes.string,
+    applyZOrder: PropTypes.bool
   }
 
   buildNativeEventWrappers () {


### PR DESCRIPTION
Exposes `applyZOrder` prop (see [Twilio docs](https://twilio.github.io/twilio-video-android/docs/1.3.7/com/twilio/video/VideoView.html)) so we can specify which video tracks are 'on top' of others.

On Android, video views [aren't really part of the view hierarchy](https://developer.android.com/reference/android/view/SurfaceView), and don't respect z-indexes.

This code has been lifted (and fixed up) from an [un-merged PR](https://github.com/blackuy/react-native-twilio-video-webrtc/pull/375) in the main blackuy repo.

This fixes glitches on Android where intersecting videos (e.g. group call previews on top of the main video) render erratically.

Related goalie-2-mobile-app PR: https://github.com/senseobservationsystems/goalie-2-mobile-app/pull/4220