### PR TITLE
Fix enable local video

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -851,12 +851,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     }
 
     public void toggleVideo(boolean enabled, ReadableMap cameraSettings) {
-        // // ND Check if ready
-        // if (cameraCapturer == null) {
-        //     Log.d("toggleVideo", "not ready");
-        //     return;
-        // }
-
         if (cameraSettings != null) {
             if (cameraSettings.hasKey("maxDimensions")) {
                 this.maxCaptureDimensions = parseDimensionsString(cameraSettings.getString("maxDimensions"));
@@ -888,6 +882,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
 
         if (localVideoTrack != null) {
             localVideoTrack.enable(enabled);
+            publishLocalVideo(enabled);
 
             WritableMap event = new WritableNativeMap();
             event.putBoolean("videoEnabled", enabled);

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -851,11 +851,11 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     }
 
     public void toggleVideo(boolean enabled, ReadableMap cameraSettings) {
-        // ND Check if ready
-        if (cameraCapturer == null) {
-            Log.d("toggleVideo", "not ready");
-            return;
-        }
+        // // ND Check if ready
+        // if (cameraCapturer == null) {
+        //     Log.d("toggleVideo", "not ready");
+        //     return;
+        // }
 
         if (cameraSettings != null) {
             if (cameraSettings.hasKey("maxDimensions")) {

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -314,6 +314,9 @@ RCT_REMAP_METHOD(setStereoEnabled, enabled:(BOOL)enabled setStereoEnabledWithRes
 
 
 RCT_EXPORT_METHOD(flipCamera) {
+    if (self.localVideoTrack == nil) {
+        return;
+    }
     if (self.camera) {
         AVCaptureDevicePosition position = self.camera.device.position;
         AVCaptureDevicePosition nextPosition = position == AVCaptureDevicePositionFront ? AVCaptureDevicePositionBack : AVCaptureDevicePositionFront;

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -279,6 +279,9 @@ RCT_REMAP_METHOD(setLocalAudioEnabled, enabled:(BOOL)enabled setLocalAudioEnable
 }
 
 - (bool)_setLocalVideoEnabled:(bool)enabled cameraType:(NSString *)cameraType {
+  if (self.localVideoTrack == nil) {
+    [self startLocalVideo:enabled];
+  }
   if (self.localVideoTrack != nil) {
       [self.localVideoTrack setEnabled:enabled];
       if (self.camera) {
@@ -452,18 +455,18 @@ RCT_EXPORT_METHOD(getStats) {
   }
 }
 
--(void)enableLocalVideoAtCreationTime:(BOOL *)enableVideo {
-    if(enableVideo){
-      if (self.localVideoTrack == nil) {
-          // We disabled video in a previous call, attempt to re-enable
-          [self startLocalVideo:true];
-      } else {
-          [self.localVideoTrack setEnabled:true];
-      }
-    } else {
-        [self stopLocalVideo];
-    }
-}
+// -(void)enableLocalVideoAtCreationTime:(BOOL *)enableVideo {
+//     if(enableVideo){
+//       if (self.localVideoTrack == nil) {
+//           // We disabled video in a previous call, attempt to re-enable
+//           [self startLocalVideo:true];
+//       } else {
+//           [self.localVideoTrack setEnabled:true];
+//       }
+//     } else {
+//         [self stopLocalVideo];
+//     }
+// }
 
 -(TVITrackPriority)parsePriorityString:(NSString *)priority {
     if (priority == nil) {
@@ -589,7 +592,7 @@ RCT_EXPORT_METHOD(getStats) {
 }
 
 RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableAudio:(BOOL *)enableAudio enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled cameraType:(NSString *)cameraType bandwidthProfileOptions:(NSDictionary *)bandwidthProfileOptions) {
-  [self enableLocalVideoAtCreationTime: enableVideo];
+  // [self enableLocalVideoAtCreationTime: enableVideo];
   TVIVideoBandwidthProfileOptions* videoBandwidthProfile = [self prepareBandwidthProfile:bandwidthProfileOptions];
 
   [self _setLocalVideoEnabled:enableVideo cameraType:cameraType];

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -455,19 +455,6 @@ RCT_EXPORT_METHOD(getStats) {
   }
 }
 
-// -(void)enableLocalVideoAtCreationTime:(BOOL *)enableVideo {
-//     if(enableVideo){
-//       if (self.localVideoTrack == nil) {
-//           // We disabled video in a previous call, attempt to re-enable
-//           [self startLocalVideo:true];
-//       } else {
-//           [self.localVideoTrack setEnabled:true];
-//       }
-//     } else {
-//         [self stopLocalVideo];
-//     }
-// }
-
 -(TVITrackPriority)parsePriorityString:(NSString *)priority {
     if (priority == nil) {
         return nil;
@@ -592,7 +579,6 @@ RCT_EXPORT_METHOD(getStats) {
 }
 
 RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableAudio:(BOOL *)enableAudio enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled cameraType:(NSString *)cameraType bandwidthProfileOptions:(NSDictionary *)bandwidthProfileOptions) {
-  // [self enableLocalVideoAtCreationTime: enableVideo];
   TVIVideoBandwidthProfileOptions* videoBandwidthProfile = [self prepareBandwidthProfile:bandwidthProfileOptions];
 
   [self _setLocalVideoEnabled:enableVideo cameraType:cameraType];

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -279,6 +279,9 @@ RCT_REMAP_METHOD(setLocalAudioEnabled, enabled:(BOOL)enabled setLocalAudioEnable
 }
 
 - (bool)_setLocalVideoEnabled:(bool)enabled cameraType:(NSString *)cameraType {
+  if (self.localVideoTrack == nil && enabled) {
+    [self startLocalVideo:true];
+  }
   if (self.localVideoTrack != nil) {
       [self.localVideoTrack setEnabled:enabled];
       if (self.camera) {

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -279,9 +279,6 @@ RCT_REMAP_METHOD(setLocalAudioEnabled, enabled:(BOOL)enabled setLocalAudioEnable
 }
 
 - (bool)_setLocalVideoEnabled:(bool)enabled cameraType:(NSString *)cameraType {
-  if (self.localVideoTrack == nil) {
-    [self startLocalVideo:enabled];
-  }
   if (self.localVideoTrack != nil) {
       [self.localVideoTrack setEnabled:enabled];
       if (self.camera) {


### PR DESCRIPTION
Related goalie-2-mobile-app issue: https://github.com/senseobservationsystems/goalie-2-mobile-app/issues/5024

This PR fixes an issue where the local video couldn't be enabled on calls started as audio-only.

On iOS, I've removed the `enableLocalVideoAtCreationTime` function (which was unique to our fork), and added a check to `_setLocalVideoEnabled` which starts the local video.

I've also added a check to the `flipCamera` function to avoid a crash that occurs when this function is called when the local video is disabled.

On Android, I've removed an unnecessary early return check in `toggleVideo`, and added `publishLocalVideo(enabled)` as per [this](https://github.com/blackuy/react-native-twilio-video-webrtc/pull/561) upstream PR.

