### PR TITLE
5552 - Fix Bluetooth Output

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -126,7 +126,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     private boolean maintainVideoTrackInBackground = false;
     private String cameraType = "";
     private boolean enableH264Codec = false;
-    private final NDExtra ndExtra =new NDExtra();
+    private final NDExtra ndExtra =new NDExtra(getContext());
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({Events.ON_CAMERA_SWITCHED,
             Events.ON_VIDEO_CHANGED,
@@ -232,7 +232,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
          */
         audioManager = (AudioManager) themedReactContext.getSystemService(Context.AUDIO_SERVICE);
         myNoisyAudioStreamReceiver = new BecomingNoisyReceiver();
-        intentFilter = new IntentFilter(Intent.ACTION_HEADSET_PLUG);
+        intentFilter = new IntentFilter();
+        intentFilter.addAction(Intent.ACTION_HEADSET_PLUG);
+        intentFilter.addAction(NDExtra.BT_INTENT);
 
         // Create the local data track
         // localDataTrack = LocalDataTrack.create(this);
@@ -638,7 +640,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         @Override
         public void onReceive(Context context, Intent intent) {
 //            audioManager.setSpeakerphoneOn(true);
-            if (Intent.ACTION_HEADSET_PLUG.equals(intent.getAction())) {
+            if (Intent.ACTION_HEADSET_PLUG.equals(intent.getAction()) || NDExtra.BT_INTENT.equals(intent.getAction())) {
                 setAudioType();
             }
         }
@@ -670,6 +672,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             cameraCapturer.stopCapture();
             cameraCapturer = null;
         }
+        ndExtra.cleanUp();
     }
 
     // ===== SEND STRING ON DATA TRACK ======================================================================

--- a/android/src/main/java/com/twiliorn/library/niceday/NDExtra.java
+++ b/android/src/main/java/com/twiliorn/library/niceday/NDExtra.java
@@ -3,6 +3,9 @@ package com.twiliorn.library.niceday;
 import static com.twiliorn.library.niceday.NDHelper.parseDimensionsString;
 import static com.twiliorn.library.niceday.NDHelper.parsePriorityString;
 
+import android.content.Context;
+import android.content.Intent;
+import android.os.Handler;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
@@ -25,11 +28,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
-This class contains changes on CustomTwilioVideoView.
-We put it on separate file to minimizes conflict when merging from upstream.
-NOTE: This class should only be used on CustomTwilioVideoView.
+ * This class contains changes on CustomTwilioVideoView.
+ * We put it on separate file to minimizes conflict when merging from upstream.
+ * NOTE: This class should only be used on CustomTwilioVideoView.
  */
 public class NDExtra {
+    public static final String BT_INTENT = "com.twiliorn.library.niceday.bluetooth";
     private static final String TAG = "BandwidthProfile";
     private static final VideoDimensions DEFAULT_MAX_CAPTURE_RESOLUTION = VideoDimensions.CIF_VIDEO_DIMENSIONS;
     private static final int DEFAULT_MAX_CAPTURE_FPS = 25;
@@ -40,6 +44,22 @@ public class NDExtra {
     public boolean isVideoEnabled;
     public VideoDimensions maxCaptureDimensions = DEFAULT_MAX_CAPTURE_RESOLUTION;
     public int maxCaptureFPS = DEFAULT_MAX_CAPTURE_FPS;
+    Context appContext;
+    Handler handler = new Handler();
+    int delay = 2000;
+    Runnable run = new Runnable() {
+        public void run() {
+            Log.d(TAG,"RUNNING");
+            Intent intent = new Intent(BT_INTENT);
+            appContext.sendBroadcast(intent);
+            handler.postDelayed(this, delay);
+        }
+    };
+
+    public NDExtra(Context appContext) {
+        this.appContext = appContext;
+        btHeadsetListener();
+    }
 
     public BandwidthProfileOptions prepareBandwidthProfile(ReadableMap options) {
         BandwidthProfileMode mode = null;
@@ -200,7 +220,7 @@ public class NDExtra {
             this.maxCaptureFPS = DEFAULT_MAX_CAPTURE_FPS;
         }
     }
-    
+
     public void setTrackPriority(String trackSid, String trackPriorityString, Room room) {
         TrackPriority priority = parsePriorityString(trackPriorityString);
 
@@ -215,5 +235,18 @@ public class NDExtra {
                 }
             }
         }
+    }
+
+    public void cleanUp() {
+        try {
+            handler.removeCallbacksAndMessages(null);
+            Log.d(TAG,"cleanup");
+        } catch (Exception ignored) {
+            Log.d(TAG,ignored.getMessage());
+        }
+    }
+
+    public void btHeadsetListener() {
+        handler.postDelayed(run, delay);
     }
 }


### PR DESCRIPTION
## Description
The problem we have is audio is rerouted through loudspeaker when we connect bt in the middle of call. When it should be played in bt headset. The root cause is we don't know when a bt headset connected/disconnected.

Current filter `ACTION_HEADSET_PLUG` only work for the first time, and for the next time it[ only works for wired headset.](https://developer.android.com/reference/android/media/AudioManager#ACTION_HEADSET_PLUG)

We also have filter `ACTION_AUDIO_BECOMING_NOISY` but it only fired when we disconnected bt, and some it get delayed or not fired at all, so we can't rely on it.

Next, we also have `BluetoothProfile.ServiceListener`, but it also only work on disconnect, while on connect event it will be fired after we turn on back bt again (but before headset is connected), but what we want is we get connected event at the time bt headset connected. (case: turn off bt during call, then turn on again, then connect bt headset, or wait sec to connect automatically). There is a possibility we can make it work using this, but it needs bt permission.

So for now, the working solution for this problem is we check every 2 sec if audio output has been changed during call, and let `setAudioType` to set a proper output. the timer will be cancelled when we hang up or start new call.

## Test Plan
- Make a call use wired/bt headset or without it
- Try to disconnect it during call (for bt, you can turn it off)
- Audio should be played on loudspeaker.
- Try to connect it again.
- Audio should be played on that headset (bt or wired)


